### PR TITLE
Add brunch as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "brunch": "^2.0.0",
     "javascript-brunch": "^2.0.0",
     "css-brunch": "^2.0.0",
     "uglify-js-brunch": "^2.0.0",


### PR DESCRIPTION
It's encouraged to use brunch 2 as a local dependency, so I'm modifying the default skeleton to include it.