### PR TITLE
Use the project specific brunch executable instead of the global one.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "version": "0.0.1",
   "repository": "",
   "scripts": {
-    "start": "brunch watch --server",
-    "build": "brunch build --production"
+    "start": "./node_modules/.bin/brunch watch --server",
+    "build": "./node_modules/.bin/brunch build --production"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Hi, I think this change might make it easier for people to work on brunch projects collaboratively. Most people creating a project will have brunch installed globally, but other coders who wish to contribute to their project may not. For those users who have not installed brunch globally, this change makes it so that their npm scripts still work.

What do you think?